### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,12 +20,12 @@ subject to a Simplified BSD License) in Contributions.
 ## Other Resources
 
 Discussion of this work occurs on the
-[wugh working group mailing list](https://mailarchive.ietf.org/arch/browse/wugh/)
-([subscribe](https://www.ietf.org/mailman/listinfo/wugh)).  In addition to
+[ietf-and-github working group mailing list](https://mailarchive.ietf.org/arch/browse/ietf-and-github/)
+([subscribe](https://www.ietf.org/mailman/listinfo/ietf-and-github)).  In addition to
 contributions in github, you are encouraged to participate in discussions there.
 
 **Note**: Some working groups adopt a policy whereby substantive discussion of
 technical issues needs to occur on the mailing list.
 
 You might also like to familiarize yourself with other
-[working group documents](https://datatracker.ietf.org/wg/wugh/documents/).
+[working group documents](https://datatracker.ietf.org/wg/git/documents/).


### PR DESCRIPTION
WGs Using GitHub (wugh) is not a chartered group.  From what I could tell in the ietf-and-github mailing list archives, the ietf-and-github WG is the proper home for this work. So, I changed the outdated links by replacing 'wugh' with the updated text.  (Also see https://github.com/ietf-gitwg/using-github/issues/11 for some suggestions I made for a more general fix for this type of problem.)